### PR TITLE
Unfortunately, the `--raw` option doesn't exist

### DIFF
--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -69,7 +69,7 @@ in
       extraConfig = ''
         # docs https://www.mediawiki.org/wiki/Extension:QuestyCaptcha
         $wgCaptchaQuestions = [
-          "What is the output of this command: nix-instantiate --raw --eval --expr 'builtins.hashString \"sha256\" \"NixOS wiki\"' ?" => "62e65110a5a6fa4f08256f7d9ee3461412babb37dc0955531b79dcf9732c9c91"
+          "What is the output of this command: nix-instantiate --eval --expr 'builtins.hashString \"sha256\" \"NixOS wiki\"' ?" => "\"62e65110a5a6fa4f08256f7d9ee3461412babb37dc0955531b79dcf9732c9c91\""
         ];
         wfLoadExtensions([ 'ConfirmEdit/QuestyCaptcha' ]);
 


### PR DESCRIPTION
It does exist in `nix eval`, but the nix command is still experimental.