### PR TITLE
update flakes before extension

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
   contents: write
 jobs:
-  update-extensions:
+  update-wiki:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,10 +17,10 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix flake update
       - run: ./modules/nixos-wiki/update-extensions.py ./modules/nixos-wiki/extensions.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: nix flake update
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
This is because updating flakes might update the mediawiki in which case we would download different wiki extensions.