### PR TITLE
Enable Visual Editor on `Help:` and `NixOS Wiki:` namespaces

### DIFF
--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -153,7 +153,7 @@ in
         $wgGroupPermissions['user']["pagetranslation"] = true;
 
         # add extra groups
-        ## add trusted group
+       ## add trusted group
         $wgGroupPermissions['trusted'] = $wgGroupPermissions['user'];
         $wgGroupPermissions['trusted']['delete'] = true;
         # allow trusted users to manage translations
@@ -177,6 +177,12 @@ in
 
         # Block spam by regex
         $wgSpamRegex = ["/seo (software|tools)|adult toys|pornstars|casino|gambling|viagra/i"];
+
+        # Visual Editor Settings
+        $wgVisualEditorAvailableNamespaces = [
+          'Help' => true,
+          'Project' => true,
+        ];
       '';
     };
 

--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -153,7 +153,7 @@ in
         $wgGroupPermissions['user']["pagetranslation"] = true;
 
         # add extra groups
-       ## add trusted group
+        ## add trusted group
         $wgGroupPermissions['trusted'] = $wgGroupPermissions['user'];
         $wgGroupPermissions['trusted']['delete'] = true;
         # allow trusted users to manage translations


### PR DESCRIPTION
This is a small PR to enable Visual Editor on `Help:` and `NixOS Wiki:` namespaces.