### PR TITLE
Allow user css for iteration and experimentation

### DIFF
--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -177,6 +177,9 @@ in
 
         # Block spam by regex
         $wgSpamRegex = ["/seo (software|tools)|adult toys|pornstars|casino|gambling|viagra/i"];
+
+        # Allow user-defined CSS for experimentation
+        $wgAllowUserCss = true;
       '';
     };
 


### PR DESCRIPTION
The MediaWiki default behaviour since 1.3.10 has been to disable user CSS, but doing so is making iterative development on the wiki significantly more difficult. See: https://www.mediawiki.org/wiki/Manual:$wgAllowUserCss

Wikipedia allows user CSS for example, https://en.wikipedia.org/wiki/Help:User_style, and so do most wikis. Disabling it makes very little sense. (Different story for user JS, but that's still disabled in this commit)