### PR TITLE
Update license text

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright © `2023` `Jörg Thalheim`
+Copyright © 2025 NixOS Foundation and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in


### PR DESCRIPTION
Related to #256 

I updated the license text to include "NixOS Foundation and contributors" similar to how NixOS/infra does it: https://github.com/NixOS/infra/blob/88f1c42e90ab88673ddde3bf973330fb2fcf23be/LICENSE#L3