### PR TITLE
Set AuthManagerOAuth to use release zip, not revision

### DIFF
--- a/modules/nixos-wiki/extensions.nix
+++ b/modules/nixos-wiki/extensions.nix
@@ -29,7 +29,7 @@
     hash = "sha256-tLOdAsXsaP/URvKcl5QWQiyhMy70qn8Fi8g3+ecNOWQ=";
   };
   "AuthManagerOAuth" = fetchzip {
-    url = "https://github.com/mohe2015/AuthManagerOAuth/archive/refs/tags/v0.3.2.zip";
-    hash = "sha256-0jMxLX7r4w44WMvtDt421vX+s622+j7WjbK6ClS/FKk=";
+    url = "https://github.com/mohe2015/AuthManagerOAuth/releases/download/v0.3.2/AuthManagerOAuth.zip";
+    hash = "sha256-hr/DLyL6IzQs67eA46RdmuVlfCiAbq+eZCRLfjLxUpc=";
   };
 }


### PR DESCRIPTION
The revision doesn't include vendored dependencies, unlike the release zip.

Tested locally with interactive VM.

should fix #271 

See tree diff:

https://gist.github.com/doggobit0/a97b4250066c8f166300811b0da47e9e