### PR TITLE
monitoring: Enable node exporter

### DIFF
--- a/modules/monitoring.nix
+++ b/modules/monitoring.nix
@@ -6,4 +6,9 @@
   networking.firewall.extraStopCommands = ''
     ip6tables -D nixos-fw -p tcp --source 2a01:4f8:1c1a:37b2::1/128 --dport 9273 -j nixos-fw-accept || true
   '';
+
+  services.prometheus.exporters.node = {
+    enable = true;
+    openFirewall = true;
+  };
 }


### PR DESCRIPTION
I realized we don't have any metrics for the wiki on prometheus.nixos.org. As a first step this enables the prometheus node exporter which can then be scrapped via prometheus.nixos.org.

I understand that there's also a Telegraf service running due to the [srvos telegraf mixin](https://github.com/nix-community/srvos/blob/ec58f16bdb57cf3a17bba79f687945dca1703c64/nixos/mixins/telegraf.nix) but this isn't scrapped by our prometheus either. I can extend the firewall rule to allow prometheus.nixos.org and open a PR in nixos/infra to scrape Telegraf as well, but I think it's best if we stick to a single monitoring solution.