### PR TITLE
fix(css): content layout shift issue

### DIFF
--- a/pages/common.css.wiki
+++ b/pages/common.css.wiki
@@ -219,3 +219,11 @@ html.skin-theme-clientpref-night body.page-NixOS_Wiki p > span.mw-default-size i
 .table .table tr:nth-child(odd) {
   background: var(--table-even-background);
 }
+
+/* Fix CLS issue */
+.vector-toc-list-item .vector-toc-toggle .mw-ui-icon-wikimedia-expand {
+  height: 0.75rem;
+  min-height: 0.75rem;
+  min-width: 0.75rem;
+  width: 0.75rem;
+}


### PR DESCRIPTION
This PR is an attempt to fix the CLS issue we are having on desktop devices.

See [Chrome UX Report for Hydra page](https://cruxvis.withgoogle.com/#/?view=visstability&url=https%3A%2F%2Fwiki.nixos.org%2Fwiki%2FHydra&identifier=origin&device=DESKTOP&periodStart=0&periodEnd=-1&display=p75s).

Tested locally with the test VM and without caching: got a CLS of 0.