### PR TITLE
mediawiki: map virtual-translate domain to fix DBQueryError

### DIFF
--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -212,6 +212,10 @@ in
 
         $wgPygmentizePath = "${pkgs.python3Packages.pygments}/bin/pygmentize";
 
+        # Map virtual-translate domain to the wiki's own database
+        # Required for Translate extension tables (e.g. translate_message_group_subscriptions)
+        $wgVirtualDomainsMapping['virtual-translate'] = [ 'db' => false ];
+
         # Enable Translate extension for all users
         $wgGroupPermissions['user']["translate"] = true;
         $wgGroupPermissions['user']["pagetranslation"] = true;


### PR DESCRIPTION
Without this mapping, update.php skips creating tables like translate_message_group_subscriptions, causing runtime errors when the Translate extension queries them.