### PR TITLE
Wrap captcha question command in HTML code tag

### DIFF
--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -107,7 +107,7 @@ in
         wfLoadExtensions([ 'ConfirmEdit/QuestyCaptcha' ]);
 
         $wgCaptchaQuestions = [
-          "What is the output of this command: nix-instantiate --eval --expr 'builtins.hashString \"sha256\" \"NixOS wiki\"' ?" => ['62e65110a5a6fa4f08256f7d9ee3461412babb37dc0955531b79dcf9732c9c91', '"62e65110a5a6fa4f08256f7d9ee3461412babb37dc0955531b79dcf9732c9c91"']
+          "What is the output of this command: <code>nix-instantiate --eval --expr 'builtins.hashString \"sha256\" \"NixOS wiki\"'</code>?" => ['62e65110a5a6fa4f08256f7d9ee3461412babb37dc0955531b79dcf9732c9c91', '"62e65110a5a6fa4f08256f7d9ee3461412babb37dc0955531b79dcf9732c9c91"']
         ];
 
         # Configure captcha to trigger only on account creation


### PR DESCRIPTION
Just noticed that the command is not in an in-line code tag which irritated my aesthetic feelings. Also removed the trailing space.

Should also improve comprehensibility and accessibility.