### PR TITLE
nixos-wiki: use AuthManagerOAuth build without bundled psr/http-message

### DIFF
--- a/checks/test.nix
+++ b/checks/test.nix
@@ -67,6 +67,9 @@
     # Check for title in HTML
     assert "Automatic synchronization from git repository" in test_page, f"Expected title not found in test page: {test_page}"
 
+    with subtest("rest.php works with AuthManagerOAuth's bundled vendor dir"):
+        wiki.succeed("curl -sf 'http://nixos-wiki.example.com/w/rest.php/v1/search/title?q=wiki&limit=1'")
+
     with subtest("FastlyPurge extension is registered"):
         exts = wiki.succeed("curl -sf 'http://nixos-wiki.example.com/w/api.php?action=query&meta=siteinfo&siprop=extensions&format=json'")
         assert '"FastlyPurge"' in exts, exts

--- a/modules/nixos-wiki/extensions.json
+++ b/modules/nixos-wiki/extensions.json
@@ -7,7 +7,7 @@
   "Description2": {},
   "AuthManagerOAuth": {
     "type": "github",
-    "github_repo": "mohe2015/AuthManagerOAuth",
+    "github_repo": "Mic92/AuthManagerOAuth",
     "github_type": "release"
   }
 }

--- a/modules/nixos-wiki/extensions.nix
+++ b/modules/nixos-wiki/extensions.nix
@@ -4,8 +4,8 @@
     hash = "sha256-VFE5AdOgfbRllR2pS6fJQbVWDdAJ9mxhgu1PBXr+CIY=";
   };
   "DarkMode" = fetchzip {
-    url = "https://github.com/NixOS/nixos-wiki-infra/releases/download/DarkMode-REL1_46-a15d4d3.tar.gz/DarkMode-REL1_46-a15d4d3.tar.gz";
-    hash = "sha256-TZMlCkYvopzZByjr1AP7y5y/aF0Ytxl0eOxw7cnvblA=";
+    url = "https://github.com/NixOS/nixos-wiki-infra/releases/download/DarkMode-REL1_46-c6eb712.tar.gz/DarkMode-REL1_46-c6eb712.tar.gz";
+    hash = "sha256-IGMPv/Ncx6ErdAXghXABtwTziyaHPuY/WrKVBhAb2YA=";
   };
   "QuickInstantCommons" = fetchzip {
     url = "https://github.com/NixOS/nixos-wiki-infra/releases/download/QuickInstantCommons-REL1_46-64d4fb9.tar.gz/QuickInstantCommons-REL1_46-64d4fb9.tar.gz";
@@ -24,7 +24,7 @@
     hash = "sha256-+EUe474suukKZpiyAel4fFOzlG2OlP8SW78XirMLpZQ=";
   };
   "AuthManagerOAuth" = fetchzip {
-    url = "https://github.com/mohe2015/AuthManagerOAuth/releases/download/v0.3.3/AuthManagerOAuth.zip";
-    hash = "sha256-xReQzh/ZcQsOD/qb3iqbgSeNOh+7pE6d7h6Sc/aHyTw=";
+    url = "https://github.com/Mic92/AuthManagerOAuth/releases/download/v0.3.3-nixos.1/AuthManagerOAuth.zip";
+    hash = "sha256-WQ8guQxHBagEJRJYhTigT9bf/45670q+GxHN2nJZxg8=";
   };
 }


### PR DESCRIPTION
The upstream release zip bundles psr/http-message 1.x and guzzle, which
shadow the 2.x copies MediaWiki core is written against and make every
rest.php request (search autocomplete) fail with a PHP fatal error.
Switch to a fork with https://github.com/mohe2015/AuthManagerOAuth/pull/66
until upstream releases it.
