### PR TITLE
nixos-wiki: log client address, Fastly vs. direct and fastcgi cache status

### DIFF
--- a/modules/nixos-wiki/fastly.nix
+++ b/modules/nixos-wiki/fastly.nix
@@ -48,12 +48,23 @@ in
       ${lib.concatMapStrings (r: "set_real_ip_from ${r};\n") fastlyRanges}
       # Set by Fastly on the edge; the VCL must overwrite any client supplied value.
       real_ip_header Fastly-Client-IP;
+
+      # $realip_remote_addr is the connecting peer, $remote_addr the client
+      geo $realip_remote_addr $via {
+        default direct;
+        ${lib.concatMapStrings (r: "${r} fastly;\n") fastlyRanges}
+      }
+      log_format wiki '$remote_addr $via $upstream_cache_status [$time_local] '
+        '"$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_time';
     '';
 
     # Fastly needs an origin name that does not point back at itself and a
     # certificate matching it (ssl_cert_hostname in nixos-infra terraform).
-    services.nginx.virtualHosts.${config.services.mediawiki.nginx.hostName}.serverAliases = [
-      cfg.originHostname
-    ];
+    services.nginx.virtualHosts.${config.services.mediawiki.nginx.hostName} = {
+      serverAliases = [ cfg.originHostname ];
+      extraConfig = ''
+        access_log syslog:server=unix:/dev/log,nohostname wiki;
+      '';
+    };
   };
 }


### PR DESCRIPTION
Makes origin hit ratio and the share of traffic bypassing Fastly measurable.