### PR TITLE
nixos-wiki: only answer for wiki.nixos.org to Fastly and loopback

### DIFF
--- a/checks/test.nix
+++ b/checks/test.nix
@@ -100,6 +100,11 @@
         codes = wiki.succeed(f"for i in $(seq 40); do curl -s -o /dev/null -w '%{{http_code}} ' -H 'Cookie: mediawiki_session=x' '{rc}'; done")
         assert "429" not in codes, codes
 
+    with subtest("the public hostname is only served to Fastly and loopback"):
+        ip = wiki.succeed("ip -4 -o addr show dev eth1 | grep -oP '(?<=inet )[0-9.]+'").strip()
+        wiki.fail(f"curl -sf -H 'Host: nixos-wiki.example.com' http://{ip}/wiki/Wiki_Sync_Test_Page")
+        wiki.succeed(f"curl -sf -H 'Host: origin.nixos-wiki.example.com' http://{ip}/wiki/Wiki_Sync_Test_Page")
+
     with subtest("PURGE from MediaWiki invalidates the cached page"):
         assert cache_status() == "HIT"
         # same shape as CdnCacheUpdate::naivePurge()

--- a/modules/nixos-wiki/fastly.nix
+++ b/modules/nixos-wiki/fastly.nix
@@ -48,12 +48,23 @@ in
       ${lib.concatMapStrings (r: "set_real_ip_from ${r};\n") fastlyRanges}
       # Set by Fastly on the edge; the VCL must overwrite any client supplied value.
       real_ip_header Fastly-Client-IP;
+
+      # $realip_remote_addr is the connecting peer, $remote_addr the client
+      geo $realip_remote_addr $via {
+        default direct;
+        ${lib.concatMapStrings (r: "${r} fastly;\n") fastlyRanges}
+      }
+      log_format wiki '$remote_addr $via $upstream_cache_status [$time_local] '
+        '"$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_time';
     '';
 
     # Fastly needs an origin name that does not point back at itself and a
     # certificate matching it (ssl_cert_hostname in nixos-infra terraform).
-    services.nginx.virtualHosts.${config.services.mediawiki.nginx.hostName}.serverAliases = [
-      cfg.originHostname
-    ];
+    services.nginx.virtualHosts.${config.services.mediawiki.nginx.hostName} = {
+      serverAliases = [ cfg.originHostname ];
+      extraConfig = ''
+        access_log syslog:server=unix:/dev/log,nohostname wiki;
+      '';
+    };
   };
 }

--- a/modules/nixos-wiki/fastly.nix
+++ b/modules/nixos-wiki/fastly.nix
@@ -52,6 +52,8 @@ in
       # $realip_remote_addr is the connecting peer, $remote_addr the client
       geo $realip_remote_addr $via {
         default direct;
+        127.0.0.0/8 local;
+        ::1 local;
         ${lib.concatMapStrings (r: "${r} fastly;\n") fastlyRanges}
       }
       log_format wiki '$remote_addr $via $upstream_cache_status [$time_local] '
@@ -64,6 +66,11 @@ in
       serverAliases = [ cfg.originHostname ];
       extraConfig = ''
         access_log syslog:server=unix:/dev/log,nohostname wiki;
+        # ${cfg.originHostname} and loopback (MediaWiki PURGE) stay reachable
+        set $via_host "$via:$host";
+        if ($via_host = "direct:${config.services.mediawiki.nginx.hostName}") {
+          return 444;
+        }
       '';
     };
   };


### PR DESCRIPTION
Most scraper traffic still connects to the origin address directly. he1.wiki.nixos.org stays open for deploys, ACME and debugging. Clients with stale DNS get a 421.

Not deployed. Merge a day after the DNS cutover (2026-09-12) so resolver caches have expired. Based on #359.