### PR TITLE
Revert origin lockdown for now

### DIFF
--- a/checks/test.nix
+++ b/checks/test.nix
@@ -100,11 +100,6 @@
         codes = wiki.succeed(f"for i in $(seq 40); do curl -s -o /dev/null -w '%{{http_code}} ' -H 'Cookie: mediawiki_session=x' '{rc}'; done")
         assert "429" not in codes, codes
 
-    with subtest("the public hostname is only served to Fastly and loopback"):
-        ip = wiki.succeed("ip -4 -o addr show dev eth1 | grep -oP '(?<=inet )[0-9.]+'").strip()
-        wiki.fail(f"curl -sf -H 'Host: nixos-wiki.example.com' http://{ip}/wiki/Wiki_Sync_Test_Page")
-        wiki.succeed(f"curl -sf -H 'Host: origin.nixos-wiki.example.com' http://{ip}/wiki/Wiki_Sync_Test_Page")
-
     with subtest("PURGE from MediaWiki invalidates the cached page"):
         assert cache_status() == "HIT"
         # same shape as CdnCacheUpdate::naivePurge()

--- a/modules/nixos-wiki/fastly.nix
+++ b/modules/nixos-wiki/fastly.nix
@@ -52,8 +52,6 @@ in
       # $realip_remote_addr is the connecting peer, $remote_addr the client
       geo $realip_remote_addr $via {
         default direct;
-        127.0.0.0/8 local;
-        ::1 local;
         ${lib.concatMapStrings (r: "${r} fastly;\n") fastlyRanges}
       }
       log_format wiki '$remote_addr $via $upstream_cache_status [$time_local] '
@@ -66,11 +64,6 @@ in
       serverAliases = [ cfg.originHostname ];
       extraConfig = ''
         access_log syslog:server=unix:/dev/log,nohostname wiki;
-        # ${cfg.originHostname} and loopback (MediaWiki PURGE) stay reachable
-        set $via_host "$via:$host";
-        if ($via_host = "direct:${config.services.mediawiki.nginx.hostName}") {
-          return 444;
-        }
       '';
     };
   };


### PR DESCRIPTION
Resolvers still had the pre-Fastly address cached, so browsers hit the origin directly and got a dropped connection. Already rolled back on the machine. Redo in a day with 421 instead of 444.