### PR TITLE
nixos-wiki: refuse scraper URL classes that bypass Fastly

### DIFF
--- a/checks/test.nix
+++ b/checks/test.nix
@@ -100,6 +100,12 @@
         codes = wiki.succeed(f"for i in $(seq 40); do curl -s -o /dev/null -w '%{{http_code}} ' -H 'Cookie: mediawiki_session=x' '{rc}'; done")
         assert "429" not in codes, codes
 
+    with subtest("scraper URL classes that bypass Fastly are refused"):
+        ip = wiki.succeed("ip -4 -o addr show dev eth1 | grep -oP '(?<=inet )[0-9.]+'").strip()
+        code = wiki.succeed(f"curl -s -o /dev/null -w '%{{http_code}}' -H 'Host: nixos-wiki.example.com' 'http://{ip}/w/index.php?title=Special:RecentChanges&from=1'")
+        assert code == "421", code
+        wiki.succeed(f"curl -sf -o /dev/null -H 'Host: nixos-wiki.example.com' http://{ip}/wiki/Wiki_Sync_Test_Page")
+
     with subtest("PURGE from MediaWiki invalidates the cached page"):
         assert cache_status() == "HIT"
         # same shape as CdnCacheUpdate::naivePurge()

--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -432,8 +432,8 @@ in
         }
         map "$has_session$request_uri" $expensive_anon {
           default "";
-          "~^0/w/index\.php\?.*title=Special(:|%3A)(RecentChanges|RecentChangesLinked|UserLogin|CreateAccount|Log|Contributions|WhatLinksHere|MobileDiff)" 1;
-          "~^0/w/index\.php\?.*(mobileaction=toggle_view|action=history|diff=|oldid=)" 1;
+          "~^0/w/index\.php\?.*title=Special(:|%3A)(RecentChanges|RecentChangesLinked|UserLogin|CreateAccount|Log|Contributions|WhatLinksHere|MobileDiff|Translate)" 1;
+          "~^0/w/index\.php\?.*(mobileaction=toggle_view|action=history|action=edit|action=submit|diff=|oldid=)" 1;
           "~^0/wiki/Special:(RecentChanges|RecentChangesLinked|Log|Contributions|WhatLinksHere)" 1;
           "~^0/w/api\.php\?.*(action=feedrecentchanges|action=feedcontributions|list=recentchanges|rcprop=)" 1;
         }

--- a/modules/nixos-wiki/fastly.nix
+++ b/modules/nixos-wiki/fastly.nix
@@ -52,6 +52,8 @@ in
       # $realip_remote_addr is the connecting peer, $remote_addr the client
       geo $realip_remote_addr $via {
         default direct;
+        127.0.0.0/8 local;
+        ::1 local;
         ${lib.concatMapStrings (r: "${r} fastly;\n") fastlyRanges}
       }
       log_format wiki '$remote_addr $via $upstream_cache_status [$time_local] '
@@ -64,6 +66,11 @@ in
       serverAliases = [ cfg.originHostname ];
       extraConfig = ''
         access_log syslog:server=unix:/dev/log,nohostname wiki;
+        # scraper URL classes must come through Fastly (see $expensive_anon)
+        set $direct_expensive "$via$expensive_anon";
+        if ($direct_expensive = direct1) {
+          return 421;
+        }
       '';
     };
   };


### PR DESCRIPTION
Stale resolvers still send the botnet to the origin address, where the shared limit_req bucket let enough through to keep PHP-FPM saturated. Direct requests for those URL classes get a 421, normal pages are still served directly. Also adds Special:Translate and edit URLs to the throttled set. Based on #361. Deployed.