### PR TITLE
nixos-wiki: size opcache to fit the code base

### DIFF
--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -282,6 +282,15 @@ in
       in
       ''
         extension=${extensions.yaml}/lib/php/extensions/yaml.so
+        ; The default 128M holds ~60% of MediaWiki + extensions, the rest was
+        ; recompiled on every request. Code lives in the nix store, so mtime
+        ; checks are pointless.
+        opcache.memory_consumption = 512
+        opcache.interned_strings_buffer = 32
+        opcache.max_accelerated_files = 32531
+        opcache.validate_timestamps = 0
+        opcache.jit_buffer_size = 64M
+        apc.shm_size = 128M
       '';
 
     services.postgresql.package = pkgs.postgresql_16;


### PR DESCRIPTION
perf showed 36% of PHP-FPM CPU in zend_compile: the 128M default opcache was full (hit rate 61%), so about 40% of files were recompiled on every request. Also enables the JIT and skips mtime checks since the code lives in the nix store. Based on #363. Deployed.