### PR TITLE
nixos-wiki: double PHP-FPM workers now that each one is cheaper

### DIFF
--- a/modules/nixos-wiki/default.nix
+++ b/modules/nixos-wiki/default.nix
@@ -76,14 +76,14 @@ in
       uploadsDir = "/var/lib/mediawiki-uploads/";
       passwordFile = if cfg.testMode then pkgs.writeText "pass" "nixos-wiki00" else cfg.adminPasswordFile;
 
-      # Page rendering is CPU bound; more workers than ~2/core only thrash
-      # and keep Postgres transactions open under scraper load.
+      # ~45MB private per worker with a warm opcache; 4/core leaves room for
+      # requests that wait on Postgres or memcached without thrashing.
       poolConfig = {
         "pm" = "dynamic";
-        "pm.max_children" = 16;
+        "pm.max_children" = 32;
         "pm.start_servers" = 8;
         "pm.min_spare_servers" = 4;
-        "pm.max_spare_servers" = 8;
+        "pm.max_spare_servers" = 12;
         "pm.max_requests" = 1000;
         # nginx gives up after 60s anyway, stop working for clients that left
         "request_terminate_timeout" = "20s";

--- a/modules/nixos-wiki/fastly.nix
+++ b/modules/nixos-wiki/fastly.nix
@@ -46,7 +46,7 @@ in
 
     services.nginx.commonHttpConfig = ''
       ${lib.concatMapStrings (r: "set_real_ip_from ${r};\n") fastlyRanges}
-      # Set by Fastly on the edge; the VCL must overwrite any client supplied value.
+      # Set by Fastly on the edge. The VCL must overwrite any client supplied value.
       real_ip_header Fastly-Client-IP;
 
       # $realip_remote_addr is the connecting peer, $remote_addr the client

--- a/modules/nixos-wiki/pygments-server.nix
+++ b/modules/nixos-wiki/pygments-server.nix
@@ -4,7 +4,7 @@ let
 in
 {
   # SyntaxHighlight forks pygmentize per <syntaxhighlight> block on every
-  # parse; ~180ms each, almost all of it interpreter start-up.
+  # parse. That is ~180ms each, almost all of it interpreter start-up.
   services.mediawiki.extraConfig = ''
     $wgPygmentizePath = "${package}/bin/pygmentize";
   '';


### PR DESCRIPTION
Headroom for the next scraper wave, ~45MB private per worker. Based on #365. Deployed.